### PR TITLE
changed the default WP_ENV to staging

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -21,9 +21,9 @@ if (file_exists($root_dir . '/.env')) {
 
 /**
  * Set up our global environment constant and load its config first
- * Default: development
+ * Default: staging
  */
-define('WP_ENV', env('WP_ENV') ?: 'development');
+define('WP_ENV', env('WP_ENV') ?: 'staging');
 
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 


### PR DESCRIPTION
If this is forgotten, I think it is better to have staging setup than development setup, don't show php errors.