### PR TITLE
Suppress nginx access log to reduce log noise.

### DIFF
--- a/config/heroku/nginx.conf
+++ b/config/heroku/nginx.conf
@@ -12,6 +12,7 @@ server_tokens off;
 fastcgi_hide_header X-Powered-By;
 fastcgi_hide_header X-Pingback;
 add_header X-Frame-Options "SAMEORIGIN";
+access_log off;
 
 charset utf8;
 


### PR DESCRIPTION
The same information will be provided by Heroku router.
